### PR TITLE
Adapt to Meteor 1.3

### DIFF
--- a/lib/nudge.js
+++ b/lib/nudge.js
@@ -22,7 +22,7 @@ if (!Object.is) {
 /**
 * Map any newly-added underscore methods to Meteor's underscore.
 */
-const uLatest = exports._;
+const uLatest = underscoreLatest._;
 let uMeteor = _;
 if (Object.is(uMeteor, uLatest)){ return; }
 const newMethods = uLatest.omit(uLatest, Object.keys(uMeteor));

--- a/lib/pre.js
+++ b/lib/pre.js
@@ -1,1 +1,1 @@
-exports = {};
+underscoreLatest = require("../underscore/underscore-min.js");

--- a/package.js
+++ b/package.js
@@ -14,7 +14,6 @@ Package.onUse(function(api) {
   ]);
   api.addFiles([
     'lib/pre.js',
-    'underscore/underscore-min.js',
     'lib/nudge.js'
   ]);
 });


### PR DESCRIPTION
A sequence of api.addFiles() no longer results in concatenating the
files; use the require() function instead
